### PR TITLE
libgsasl 1.10.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,7 @@ cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* ./build-aux
 ./configure --with-gssapi-impl=mit --prefix=$PREFIX --build=${BUILD} --host=${HOST}
 make -j${CPU_COUNT} ${VERBOSE_AT}
 
- Attempt to fix some file number limits on testing on osx.
+# Attempt to fix some file number limits on testing on osx.
 if [[ ${target_platform} == osx-* ]]; then
     sudo sysctl -w kern.maxfiles=64000
     sudo sysctl -w kern.maxfilesperproc=64000

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,7 @@
 
 cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* ./build-aux
 
-./configure --with-gssapi-impl=mit --prefix=$PREFIX --build=${BUILD} --host=${HOST}
+./configure --with-gssapi-impl=mit --with-libgcrypt --prefix=$PREFIX --build=${BUILD} --host=${HOST}
 make -j${CPU_COUNT} ${VERBOSE_AT}
 
 # Attempt to fix some file number limits on testing on osx.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 
+set -x
+
 cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* ./build-aux
 
-./configure --with-gssapi-impl=mit --with-libgcrypt --prefix=$PREFIX --build=${BUILD} --host=${HOST}
+./configure --help
+
+./configure --with-gssapi-impl=mit --with-libgcrypt --with-openssl=auto --prefix=$PREFIX --build=${BUILD} --host=${HOST}
 make -j${CPU_COUNT} ${VERBOSE_AT}
 
 # Attempt to fix some file number limits on testing on osx.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,7 +6,7 @@ cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* ./build-aux
 
 ./configure --help
 
-./configure --with-gssapi-impl=mit --with-libgcrypt --with-openssl=auto --prefix=$PREFIX --build=${BUILD} --host=${HOST}
+./configure --with-gssapi-impl=mit --with-libgcrypt --prefix=$PREFIX --build=${BUILD} --host=${HOST}
 make -j${CPU_COUNT} ${VERBOSE_AT}
 
 # Attempt to fix some file number limits on testing on osx.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,14 +24,15 @@ requirements:
     - make  # [unix]
     - libtool  # [not win]
   host:
-    - libgcrypt
-    - libntlm >=0.3.1
     - krb5
+    - libgcrypt
+    - libntlm
   run:
+    - krb5
     - libgcrypt
     - libgpg-error  # [linux]
     - libntlm >=0.3.1
-    - krb5
+    - openssl
 
 test:
   commands:
@@ -49,6 +50,9 @@ about:
   home: http://www.gnu.org/software/gsasl/
   license: LGPL-2.1-or-later
   license_family: LGPL
+  license_file: 
+    - COPYING.LIB
+    - COPYING
   summary: Implementation of the Simple Authentication and Security Layer framework
   doc_url: https://www.gnu.org/software/gsasl/manual/
   dev_url: https://git.savannah.gnu.org/cgit/gsasl.git

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,13 +26,11 @@ requirements:
   host:
     - krb5
     - libgcrypt
+    - libgpg-error  # [linux]
     - libntlm
   run:
     - krb5
     - libgcrypt
-    - libgpg-error  # [linux]
-    - libntlm >=0.3.1
-    - openssl
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libgsasl" %}
-{% set version = "1.8.1" %}
+{% set version = "1.10.0" %}
 
 package:
   name: "{{ name }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://ftp.gnu.org/gnu/gsasl/{{ name }}-{{ version }}.tar.gz
-  sha256: 19e2f90525c531010918c50bb1febef0d7115d620150cc66153b9ce73ff814e6
+  sha256: f1b553384dedbd87478449775546a358d6f5140c15cccc8fb574136fdc77329f
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,6 @@ build:
   run_exports:
     # unknown.  Leaving defaults.
     - {{ pin_subpackage('libgsasl') }}
-  ignore_run_exports:
-    - libgcrypt
 
 requirements:
   build:
@@ -27,6 +25,11 @@ requirements:
     - libtool  # [not win]
   host:
     - libgcrypt
+    - libntlm >=0.3.1
+    - krb5
+  run:
+    - libgcrypt
+    - libgpg-error  # [linux]
     - libntlm >=0.3.1
     - krb5
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,9 +28,6 @@ requirements:
     - libgcrypt
     - libgpg-error  # [linux]
     - libntlm
-  run:
-    - krb5
-    - libgcrypt
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,8 @@ build:
   run_exports:
     # unknown.  Leaving defaults.
     - {{ pin_subpackage('libgsasl') }}
+  ignore_run_exports:
+    - libgcrypt
 
 requirements:
   build:
@@ -24,7 +26,7 @@ requirements:
     - libtool  # [not win]
   host:
     - libgcrypt
-    - libntlm
+    - libntlm >=0.3.1
     - krb5
 
 test:
@@ -35,13 +37,17 @@ test:
     - test -f $PREFIX/lib/libgsasl.a
     - test -f $PREFIX/lib/libgsasl.so         # [linux]
     - test -f $PREFIX/lib/libgsasl.so.7       # [linux]
-    - test -f $PREFIX/lib/libgsasl.so.7.9.6   # [linux]
+    - test -f $PREFIX/lib/libgsasl.so.7.10.0   # [linux]
+    - test -f $PREFIX/lib/libgsasl$SHLIB_EXT  # [unix]
+    - test -f $PREFIX/lib/libgsasl.7.dylib    # [osx]
 
 about:
   home: http://www.gnu.org/software/gsasl/
-  license: LGPL-2.1
+  license: LGPL-2.1-or-later
   license_family: LGPL
   summary: Implementation of the Simple Authentication and Security Layer framework
+  doc_url: https://www.gnu.org/software/gsasl/manual/
+  dev_url: https://git.savannah.gnu.org/cgit/gsasl.git
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   number: 0
   # This package is a dependency of libhdfs3, which is primarily used with HDFS on Linux.
-  skip: True  # [win]
+  # It's currently not available on s390x and there is no libgcrypt on s390x.
+  skip: True  # [win or s390x]
   run_exports:
     # unknown.  Leaving defaults.
     - {{ pin_subpackage('libgsasl') }}


### PR DESCRIPTION
Update libgsasl to 1.10.0

Changelog: https://git.savannah.gnu.org/gitweb/?p=gsasl.git;a=blob;f=NEWS;hb=HEAD
Dependencies: https://www.gnu.org/software/gsasl/#dependencies

Actions:
1. Skip `s390x` (no dependent `libcrypt`)
2. Use `libcrypt` in `ignore_run_exports`
3. Update tests
4. Add dev and doc urls
5. Fix comment symbol in build.sh
6. Use `libntlm >=0.3.1` in host
7. Update license
