### PR TITLE
libgsasl 1.10.0: rebuild against libkrb5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/096f9c8
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/0a7b522

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/096f9c8

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/0a7b522
+  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/baedf3b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/krb5-feedstock/pr12/baedf3b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - libtool  # [not win]
     - make     # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
     # pkgconfig file
     - test -f $PREFIX/lib/pkgconfig/libgsasl.pc
     # Locale files (Linux only)
-    - test -f $PREFIX/share/locale/*/LC_MESSAGES/libgsasl.mo    # [linux]
+    - for locale in $PREFIX/share/locale/*/LC_MESSAGES/libgsasl.mo; do test -f $locale; done  # [linux]
 
 about:
   home: https://www.gnu.org/software/gsasl/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,28 +46,7 @@ test:
     # pkgconfig file
     - test -f $PREFIX/lib/pkgconfig/libgsasl.pc
     # Locale files (Linux only)
-    - test -f $PREFIX/share/locale/da/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/de/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/en@boldquot/LC_MESSAGES/libgsasl.mo  # [linux]
-    - test -f $PREFIX/share/locale/en@quot/LC_MESSAGES/libgsasl.mo      # [linux]
-    - test -f $PREFIX/share/locale/eo/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/es/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/fi/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/fr/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/ga/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/hu/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/id/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/it/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/nl/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/pl/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/pt_BR/LC_MESSAGES/libgsasl.mo  # [linux]
-    - test -f $PREFIX/share/locale/ro/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/sk/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/sr/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/sv/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/uk/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/vi/LC_MESSAGES/libgsasl.mo    # [linux]
-    - test -f $PREFIX/share/locale/zh_CN/LC_MESSAGES/libgsasl.mo  # [linux]
+    - test -f $PREFIX/share/locale/*/LC_MESSAGES/libgsasl.mo    # [linux]
 
 about:
   home: https://www.gnu.org/software/gsasl/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,18 +2,17 @@
 {% set version = "1.10.0" %}
 
 package:
-  name: "{{ name }}"
-  version: "{{ version }}"
+  name: {{ name }}
+  version: {{ version }}
 
 source:
   url: https://ftp.gnu.org/gnu/gsasl/{{ name }}-{{ version }}.tar.gz
   sha256: f1b553384dedbd87478449775546a358d6f5140c15cccc8fb574136fdc77329f
 
 build:
-  number: 1
+  number: 2
   # This package is a dependency of libhdfs3, which is primarily used with HDFS on Linux.
-  # It's currently not available on s390x and there is no libgcrypt on s390x.
-  skip: True  # [win or s390x]
+  skip: true  # [win]
   run_exports:
     # unknown.  Leaving defaults.
     - {{ pin_subpackage('libgsasl') }}
@@ -21,31 +20,31 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - make  # [unix]
     - libtool  # [not win]
+    - make     # [unix]
   host:
-    - krb5
-    - libgcrypt
-    - libgpg-error  # [linux]
-    - libntlm
+    - libkrb5 {{ krb5 }}
+    - libgcrypt {{ libgcrypt }}
+    - libgpg-error {{ libgpg_error }}  # [linux]
+    - libntlm {{ libntlm }}
 
 test:
   commands:
     - test -f $PREFIX/include/gsasl-compat.h
     - test -f $PREFIX/include/gsasl-mech.h
     - test -f $PREFIX/include/gsasl.h
+    - test -f $PREFIX/lib/libgsasl.7.dylib    # [osx]
     - test -f $PREFIX/lib/libgsasl.a
     - test -f $PREFIX/lib/libgsasl.so         # [linux]
     - test -f $PREFIX/lib/libgsasl.so.7       # [linux]
-    - test -f $PREFIX/lib/libgsasl.so.7.10.0   # [linux]
+    - test -f $PREFIX/lib/libgsasl.so.7.10.0  # [linux]
     - test -f $PREFIX/lib/libgsasl$SHLIB_EXT  # [unix]
-    - test -f $PREFIX/lib/libgsasl.7.dylib    # [osx]
 
 about:
-  home: http://www.gnu.org/software/gsasl/
+  home: https://www.gnu.org/software/gsasl/
   license: LGPL-2.1-or-later
   license_family: LGPL
-  license_file: 
+  license_file:
     - COPYING.LIB
     - COPYING
   summary: Implementation of the Simple Authentication and Security Layer framework

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,15 +31,43 @@ requirements:
 
 test:
   commands:
+    # Header files
     - test -f $PREFIX/include/gsasl-compat.h
     - test -f $PREFIX/include/gsasl-mech.h
     - test -f $PREFIX/include/gsasl.h
-    - test -f $PREFIX/lib/libgsasl.7.dylib    # [osx]
+    # Library files
     - test -f $PREFIX/lib/libgsasl.a
+    - test -f $PREFIX/lib/libgsasl.7.dylib    # [osx]
+    - test -f $PREFIX/lib/libgsasl.dylib      # [osx]
     - test -f $PREFIX/lib/libgsasl.so         # [linux]
     - test -f $PREFIX/lib/libgsasl.so.7       # [linux]
     - test -f $PREFIX/lib/libgsasl.so.7.10.0  # [linux]
     - test -f $PREFIX/lib/libgsasl$SHLIB_EXT  # [unix]
+    # pkgconfig file
+    - test -f $PREFIX/lib/pkgconfig/libgsasl.pc
+    # Locale files (Linux only)
+    - test -f $PREFIX/share/locale/da/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/de/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/en@boldquot/LC_MESSAGES/libgsasl.mo  # [linux]
+    - test -f $PREFIX/share/locale/en@quot/LC_MESSAGES/libgsasl.mo      # [linux]
+    - test -f $PREFIX/share/locale/eo/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/es/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/fi/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/fr/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/ga/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/hu/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/id/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/it/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/nl/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/pl/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/pt_BR/LC_MESSAGES/libgsasl.mo  # [linux]
+    - test -f $PREFIX/share/locale/ro/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/sk/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/sr/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/sv/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/uk/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/vi/LC_MESSAGES/libgsasl.mo    # [linux]
+    - test -f $PREFIX/share/locale/zh_CN/LC_MESSAGES/libgsasl.mo  # [linux]
 
 about:
   home: https://www.gnu.org/software/gsasl/


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-8636](https://anaconda.atlassian.net/browse/PKG-8636) 
- [Upstream repository](https://git.savannah.gnu.org/cgit/gsasl.git)
- Issues:
  - https://github.com/ContinuumIO/anaconda-issues/issues/10772
  - https://github.com/conda-forge/krb5-feedstock/issues/48 

### Explanation of changes:

- Rebuild libgsasl against libkrb5 1.21.3 
- Updated build number from 1 to 2
- Enhanced test suite with comprehensive checks for headers, libraries

### Notes:

- This rebuild addresses downstream dependency issues with krb5 1.21.3


[PKG-8636]: https://anaconda.atlassian.net/browse/PKG-8636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ