### PR TITLE
PKG-11945-rebuild-libgsasl-1.10.0-for-libkrb5-1.22.1

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,20 +2,29 @@
 
 set -x
 
+# Create libgcrypt-config wrapper for newer libgcrypt versions
+mkdir -p $PREFIX/bin
+cat > $PREFIX/bin/libgcrypt-config << 'EOF'
+#!/bin/bash
+case "$1" in
+    --version) pkg-config --modversion libgcrypt ;;
+    --libs) pkg-config --libs libgcrypt ;;
+    --cflags) pkg-config --cflags libgcrypt ;;
+    *) pkg-config "$@" libgcrypt 2>/dev/null || exit 1 ;;
+esac
+exit 0
+EOF
+chmod +x $PREFIX/bin/libgcrypt-config
+
+# Ensure it's in PATH for configure
+export PATH=$PREFIX/bin:$PATH
+
 cp -r ${BUILD_PREFIX}/share/libtool/build-aux/config.* ./build-aux
 
 ./configure --help
 
 ./configure --with-gssapi-impl=mit --with-libgcrypt --prefix=$PREFIX --build=${BUILD} --host=${HOST}
 make -j${CPU_COUNT} ${VERBOSE_AT}
-
-# Attempt to fix some file number limits on testing on osx.
-if [[ ${target_platform} == osx-* ]]; then
-    sudo sysctl -w kern.maxfiles=64000
-    sudo sysctl -w kern.maxfilesperproc=64000
-    sudo launchctl limit maxfiles 64000 64000
-    ulimit -n 64000;
-fi
 
 if [[ "${target_platform}" != osx-* ]]; then
   make check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,11 @@ source:
   sha256: f1b553384dedbd87478449775546a358d6f5140c15cccc8fb574136fdc77329f
 
 build:
-  number: 2
-  # This package is a dependency of libhdfs3, which is primarily used with HDFS on Linux.
+  number: 3
   skip: true  # [win]
   run_exports:
-    # unknown.  Leaving defaults.
-    - {{ pin_subpackage('libgsasl') }}
+    # Unknown. Leaving defaults.
+    - {{ pin_subpackage(name) }}
 
 requirements:
   build:
@@ -23,6 +22,7 @@ requirements:
     - {{ compiler('c') }}
     - libtool  # [not win]
     - make     # [unix]
+    - pkg-config
   host:
     - libkrb5 {{ krb5 }}
     - libgcrypt {{ libgcrypt }}
@@ -49,15 +49,19 @@ test:
     - for locale in $PREFIX/share/locale/*/LC_MESSAGES/libgsasl.mo; do test -f $locale; done  # [linux]
 
 about:
-  home: https://www.gnu.org/software/gsasl/
+  home: https://www.gnu.org/software/gsasl
   license: LGPL-2.1-or-later
   license_family: LGPL
   license_file:
     - COPYING.LIB
     - COPYING
   summary: Implementation of the Simple Authentication and Security Layer framework
-  doc_url: https://www.gnu.org/software/gsasl/manual/
-  dev_url: https://git.savannah.gnu.org/cgit/gsasl.git
+  description: |
+    GNU SASL is an implementation of the Simple Authentication and Security Layer framework
+    and a few common SASL mechanisms. SASL is used by network servers (e.g., IMAP, SMTP, XMPP)
+    to request authentication from clients, and in clients to authenticate against servers.
+  doc_url: https://www.gnu.org/software/gsasl/manual
+  dev_url: https://cgit.git.savannah.gnu.org/cgit
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
[PKG-11945](https://anaconda.atlassian.net/browse/PKG-11945) Rebuild for libkrb5 1.22.1

Since `libgcrypt-config` is not a part of `libgcrypt` package anymore, it required a wrapper in build script

[PKG-11945]: https://anaconda.atlassian.net/browse/PKG-11945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ