### PR TITLE
PKG-13865 Remove ntlm usage

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - libkrb5 {{ krb5 }}
     - libgcrypt {{ libgcrypt }}
     - libgpg-error {{ libgpg_error }}  # [linux]
-    - libntlm {{ libntlm }}
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f1b553384dedbd87478449775546a358d6f5140c15cccc8fb574136fdc77329f
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
   run_exports:
     # Unknown. Leaving defaults.


### PR DESCRIPTION
## Remove NTLM support from libgsasl

### Links
- [PKG-13865](https://anaconda.atlassian.net/browse/PKG-13865) — remove libntlm usage
- [libgsasl dev](https://cgit.git.savannah.gnu.org/cgit)

### Changes
- `meta.yaml`: removed `libntlm` from `host` dependencies

### Notes
- `./configure` auto-detects ntlm support via `libntlm` presence — removing it from `host` is sufficient to disable NTLM at build time, no configure flag needed
- Windows is already skipped entirely (`skip: true # [win]`) — Linux/macOS only change

[PKG-13865]: https://anaconda.atlassian.net/browse/PKG-13865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ